### PR TITLE
fix: add getGitHubClient export alias to github-client.js

### DIFF
--- a/.github/agents/shared/github-client.js
+++ b/.github/agents/shared/github-client.js
@@ -30,6 +30,14 @@ export function createGitHubClient() {
 }
 
 /**
+ * Get GitHub client (alias for createGitHubClient for compatibility)
+ * @returns {Octokit} - Configured Octokit instance
+ */
+export function getGitHubClient() {
+  return createGitHubClient();
+}
+
+/**
  * Get issue details
  * @param {Octokit} octokit - GitHub client
  * @param {string} owner - Repository owner


### PR DESCRIPTION
- Export getGitHubClient as alias for createGitHubClient
- Ensures compatibility with planner-agent.js and code-agent.js imports
- Fixes 'does not provide an export named getGitHubClient' error