### PR TITLE
fix: update workflow to parse autoFixDecision from wrapped triage result

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -52,8 +52,8 @@ jobs:
           RESULT=$(node triage-agent.js)
           echo "$RESULT"
           
-          # Extract decision for workflow routing
-          DECISION=$(echo "$RESULT" | jq -r '.autoFixDecision // "HUMAN_REVIEW_REQUIRED"')
+          # Extract decision for workflow routing (result is wrapped in {success, data})
+          DECISION=$(echo "$RESULT" | jq -r '.data.autoFixDecision // "HUMAN_REVIEW_REQUIRED"')
           echo "decision=$DECISION" >> $GITHUB_OUTPUT
           
           # Store full result


### PR DESCRIPTION
- Change jq path from .autoFixDecision to .data.autoFixDecision
- Accounts for new { success: true, data: {...} } response format
- Ensures planner job triggers when decision is AUTO_FIX