### PR TITLE
fix: use camelCase autoFixDecision in planner agent

### DIFF
--- a/.github/agents/planner-agent.js
+++ b/.github/agents/planner-agent.js
@@ -80,8 +80,8 @@ async function runPlanner() {
   const triage = triageResult.data;
   
   // Validate auto-fix decision
-  if (triage.auto_fix_decision !== 'AUTO_FIX') {
-    throw new AutoFixError('NOT_AUTO_FIX', `Auto-fix not approved: ${triage.auto_fix_decision}`);
+  if (triage.autoFixDecision !== 'AUTO_FIX') {
+    throw new AutoFixError('NOT_AUTO_FIX', `Auto-fix not approved: ${triage.autoFixDecision}`);
   }
   
   // Get GitHub client


### PR DESCRIPTION
- Change auto_fix_decision to autoFixDecision to match triage output
- Fixes field name mismatch causing NOT_AUTO_FIX error
- Ensures planner correctly validates auto-fix approval