### PR TITLE
fix: display validation errors below input fields

### DIFF
--- a/src/components/form/FieldWrapper.vue
+++ b/src/components/form/FieldWrapper.vue
@@ -9,8 +9,7 @@
                 {{ helpText }}
             </p>
 
-            <!-- BUG: Validation error never shows because condition is always false -->
-            <ValidationError v-if="false && error" :message="error" :aria-live="'polite'" />
+            <ValidationError v-if="error" :message="error" :aria-live="'polite'" />
         </div>
     </Transition>
 </template>


### PR DESCRIPTION
Fixes #34

Removed false condition that prevented ValidationError component from rendering when form validation fails. Users can now see error messages below invalid fields as expected.

Manual testing:
1. Load any form with required fields
2. Leave field empty and submit
3. Error message now displays correctly